### PR TITLE
Remove npm update from prestart hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "license": "ISC",
   "main": "main.css",
   "scripts": {
-    "prestart": "npm update",
     "start": "npm run css",
     "precss": "concat class.css data.css root.css -o module.css",
     "css": "postcss module.css --use postcss-custom-properties --no-map -o main.css"


### PR DESCRIPTION
Updating on prestart is not always desired.